### PR TITLE
Use universal newlines approach

### DIFF
--- a/snactor/output_processors/string_list.py
+++ b/snactor/output_processors/string_list.py
@@ -15,4 +15,4 @@ class StringListOutputProcessor(object):
         self.definition = definition
 
     def process(self, output, data):
-        assign_to_variable_spec(data, self.definition.target, output.strip().split('\n'))
+        assign_to_variable_spec(data, self.definition.target, output.strip().splitlines())


### PR DESCRIPTION
This might be useful when a tool outputs data delimited by `\r\n` or when the actor uses data got through some network protocol. Example actor:

Before:
```
{'header_list': {'headers': ['HTTP/1.1 301 Moved Permanently\r',
                             'Content-Type: text/html; charset=iso-8859-1\r',
```

After:
```
{'header_list': {'headers': ['HTTP/1.1 301 Moved Permanently',
                             'Content-Type: text/html; charset=iso-8859-1',
```
