### PR TITLE
Do not try to handle stdout if there is none and none is expected

### DIFF
--- a/snactor/executors/default.py
+++ b/snactor/executors/default.py
@@ -45,11 +45,12 @@ class Executor(object):
 
     def handle_stdout(self, stdout, data):
         self.log.debug("handle_stdout(%s)", stdout)
-        try:
-            output = filter_by_channel(self.definition.outputs, json.loads(stdout))
-            data.update(output)
-        except ValueError:
-            self.log.warn("Failed to decode output: %s", stdout, exc_info=True)
+        if self.definition.outputs or stdout:
+            try:
+                output = filter_by_channel(self.definition.outputs, json.loads(stdout))
+                data.update(output)
+            except ValueError:
+                self.log.warn("Failed to decode output: %s", stdout, exc_info=True)
 
     def handle_stderr(self, stderr, data):
         self.log.debug("handle_stderr(%s)", stderr)


### PR DESCRIPTION
Currently, execution of actor will fail if there is no output