### PR TITLE
Add the possibility to filter loaded actors by tags.

### DIFF
--- a/snactor/definition.py
+++ b/snactor/definition.py
@@ -3,6 +3,7 @@ class Definition(object):
     def __init__(self, name, init=None):
         init = init or {}
         self.name = name
+        self.tags = set(init.get('tags', ()))
         self.inputs = init.get('inputs', ())
         self.outputs = init.get('outputs', ())
         if not isinstance(self.outputs, (list, tuple)):

--- a/snactor/loader/__init__.py
+++ b/snactor/loader/__init__.py
@@ -9,7 +9,7 @@ import yaml
 from snactor.definition import Definition
 from snactor.loader.extends import ExtendsActor
 from snactor.registry import register_actor, get_executor, get_actor, register_schema, get_registered_actors,\
-    get_schema
+    get_schema, actor_names_by_tags
 
 
 def _load(name, definition, tags, post_resolve):

--- a/snactor/loader/__init__.py
+++ b/snactor/loader/__init__.py
@@ -9,7 +9,7 @@ import yaml
 from snactor.definition import Definition
 from snactor.loader.extends import ExtendsActor
 from snactor.registry import register_actor, get_executor, get_actor, register_schema, get_registered_actors,\
-    get_schema, actor_names_by_tags
+    get_schema
 
 
 def _load(name, definition, tags, post_resolve):

--- a/snactor/registry/__init__.py
+++ b/snactor/registry/__init__.py
@@ -2,4 +2,4 @@ from .envs import get_environment_extension  # noqa
 from .schemas import get_schema, register_schema  # noqa
 from .executors import registered_executor, get_executor  # noqa
 from .output_processors import registered_output_processor, get_output_processor  # noqa
-from .actors import must_get_actor, register_actor, get_actor, get_registered_actors  # noqa
+from .actors import must_get_actor, register_actor, get_actor, get_registered_actors, actor_names_by_tags  # noqa

--- a/snactor/registry/actors.py
+++ b/snactor/registry/actors.py
@@ -19,6 +19,13 @@ def must_get_actor(actor):
     return _instantiate_actor(_REGISTERED_ACTORS[actor])
 
 
+def actor_names_by_tags(tags, names=()):
+    if names == ():
+        return [name for name, a  in _REGISTERED_ACTORS.items() if a[0].tags.intersection(tags)]
+    else:
+        return [name for name, a  in _REGISTERED_ACTORS.items() if a[0].tags.intersection(tags) and name in names]
+
+
 def register_actor(name, definition, executor):
     if name in _REGISTERED_ACTORS:
         raise LookupError("Actor '{}' has been already registered previously".format(name))

--- a/snactor/registry/actors.py
+++ b/snactor/registry/actors.py
@@ -21,9 +21,9 @@ def must_get_actor(actor):
 
 def actor_names_by_tags(tags, names=()):
     if names == ():
-        return [name for name, a  in _REGISTERED_ACTORS.items() if a[0].tags.intersection(tags)]
+        return [name for name, a in _REGISTERED_ACTORS.items() if a[0].tags.intersection(tags)]
     else:
-        return [name for name, a  in _REGISTERED_ACTORS.items() if a[0].tags.intersection(tags) and name in names]
+        return [name for name, a in _REGISTERED_ACTORS.items() if a[0].tags.intersection(tags) and name in names]
 
 
 def register_actor(name, definition, executor):


### PR DESCRIPTION
This is needed to be able to choose actors which have all given tags. The load() function takes a list of tags, but loads actors which have any of them. If we want to load actors which have all of them, we must load them using one of tags and then filter them using the new actor_names_by_tags function.

The motivation is that we will eventually have a large number of actors, shared among different projects (Leapp, preupgrade-assistant, ...). If we tag the preupgrade assistant ones with e.g. a "p-a" tag and use various other tags, e.g. "readonly" for actors that do not modify the system, the preupgrade-assistant application might be interested in loading only those actors that are intended for preupgrade-assistant AND are readonly. By using 
```
load(..., tags=("p-a", "readonly"))
```
it would get those that are intended for preupgrade-assistant OR readonly, which is not what it would need.

More urgently, this is needed to start composing actors using leappwf. We need to tag actors that are ready to be used with leappwf. E.g. the check-target implementation using leappwf and implicit workflow construction by dependency resolution will need to use actors tagged with "check_target", but excluding the check_target_group one. This can be done by tagging those that we want by a "depsolver" tag, but currently we don't have any means to select those that have both the "depsolver" and "check_target" tags. This PR fills this gap.