### PR TITLE
Need to add "name" into the output definition

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -12,14 +12,14 @@ Lets get a script to list all installed packages at a Fedora machine and place t
 $ ls
 list_packages.sh
 
-$ cat list_packages.sh 
+$ cat list_packages.sh
 rpm -qa > packages.txt
 
-$ bash list_packages.sh 
+$ bash list_packages.sh
 $ ls
 list_packages.sh  packages.txt
 
-$ head -5 packages.txt 
+$ head -5 packages.txt
 python3-pytest-pep8-1.0.6-9.fc26.noarch
 pcre-8.41-1.fc26.x86_64
 python2-fedora-0.9.0-6.fc26.noarch
@@ -94,7 +94,7 @@ If we run this script we can verify that our actor was executed by checking the 
 │       └── list_packages.sh
 └── execute.py
 
-$ ./execute.py 
+$ ./execute.py
 
 (...)
 ├── actors
@@ -220,7 +220,8 @@ inputs:
       name: PackageFilter
 outputs:
   - name: packages
-    type: PackagesList
+    type:
+      name: PackagesList
 description: |
   An actor to list all installed packages
 execute:


### PR DESCRIPTION
I've got this error when running ./execute.py using the actor output
definition from the documentation.

Traceback (most recent call last):
File "execute.py", line 24, in <module>
main()
File "execute.py", line 14, in main
load(actors_dir)
File "/usr/lib/python2.7/site-packages/snactor/loader/__init__.py", line 86, in load
_load(os.path.basename(root), os.path.join(root, '_actor.yaml'), tags, post_resolve)
File "/usr/lib/python2.7/site-packages/snactor/loader/__init__.py", line 39, in _load
create_actor(name, d)
File "/usr/lib/python2.7/site-packages/snactor/loader/__init__.py", line 49, in create_actor
register_actor(name, Definition(name, definition), executor)
File "/usr/lib/python2.7/site-packages/snactor/definition.py", line 33, in __init__
self.__resolve_channel_type(self.outputs)
File "/usr/lib/python2.7/site-packages/snactor/definition.py", line 20, in __resolve_channel_type
channel["type"].setdefault("version", LATEST)
AttributeError: 'str' object has no attribute 'setdefault'