### PR TITLE
Remove running tests in python 3.3 env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36
+envlist = py27, py34, py35, py36
 
 [testenv]
 deps =


### PR DESCRIPTION
Pytest does not support python 3.3 anymore (see https://pypi.python.org/pypi/pytest).