### PR TITLE
Added build/install-deps targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,18 @@ clean:
 	@find . -name '*.pyc' -exec rm -f {} +
 	@find . -name '*.pyo' -exec rm -f {} +
 
+build:
+	true
+
+install-deps:
+	pip install --upgrade setuptools
+	pip install -r requirements-tests.txt
+
 install:
 	# WORKAROUND FOR: https://github.com/ansible/ansible/issues/31741
 	pip install --upgrade setuptools
-	pip install -r requirements.txt
 	pip install .
+
 
 test:
 	py.test --flake8 --cov=snactor
@@ -16,4 +23,4 @@ test:
 test-all:
 	tox
 
-.PHONY: clean install test test-all
+.PHONY: clean build install-deps install test test-all

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,11 @@ build:
 	true
 
 install-deps:
+	# WORKAROUND FOR: https://github.com/ansible/ansible/issues/31741
 	pip install --upgrade setuptools
 	pip install -r requirements-tests.txt
 
 install:
-	# WORKAROUND FOR: https://github.com/ansible/ansible/issues/31741
-	pip install --upgrade setuptools
 	pip install .
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+six
 ansible
 PyYAML
 jsl

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Vinzenz 'evilissimo' Feenstra",
     author_email='evilissimo@redhat.com',
     description='snactor is a python library for actors',
-    install_requires=['PyYAML', 'jsl', 'argcomplete', 'jsonschema', 'six'],
+    install_requires=[],
     scripts=['tools/snactor_runner'],
     include_package_data=True,
     zip_safe=False


### PR DESCRIPTION
Adding targets into makefile
 - build - just plain true, since there is nothing to build, but we will have common targets in all projects.
 - install-deps - will install all build & runtime dependencies
 - install - will install the snactor project